### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete string escaping or encoding

### DIFF
--- a/docfx_project/templates/custom/ManagedReference.common.js
+++ b/docfx_project/templates/custom/ManagedReference.common.js
@@ -226,7 +226,7 @@ function handleItem(vm, gitContribute, gitUrlPattern) {
     "https://github.com/kblok/puppeteer-sharp/issues/new?title=Improve%20" +
     vm.name[0].value +
     "&body=Explain%20how%20would%20you%20like%20this%20document%20to%20be%20impoved.%0ASource URL: " +
-    vm.sourceurl.replace("#", "%23");
+    vm.sourceurl.replace(/#/g, "%23");
 
   // set to null incase mustache looks up
   vm.summary = vm.summary || "";


### PR DESCRIPTION
Potential fix for [https://github.com/MjrTom/puppeteer-sharp/security/code-scanning/1](https://github.com/MjrTom/puppeteer-sharp/security/code-scanning/1)

To fix the problem, we need to ensure that all occurrences of the `#` character in `vm.sourceurl` are replaced with `%23`. This can be achieved by using a regular expression with the global flag (`g`) in the `replace` method. This change will ensure that every `#` character in the string is replaced, not just the first one.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
