### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/docfx_project/templates/modern/src/markdown.ts
+++ b/docfx_project/templates/modern/src/markdown.ts
@@ -64,7 +64,7 @@ async function renderMermaid() {
   processedDiagrams.forEach(e => {
     if (e.offsetParent) {
       e.removeAttribute('data-processed')
-      e.innerHTML = e.getAttribute('data-mermaid')
+      e.textContent = e.getAttribute('data-mermaid')
       nodes.push(e)
     }
   })


### PR DESCRIPTION
Potential fix for [https://github.com/MjrTom/puppeteer-sharp/security/code-scanning/2](https://github.com/MjrTom/puppeteer-sharp/security/code-scanning/2)

To fix the problem, we need to ensure that the content of the `data-mermaid` attribute is not interpreted as HTML. Instead of setting `innerHTML` directly, we should use text content or a safer method to handle the content. One way to achieve this is by creating a text node and appending it to the parent element. This ensures that any HTML meta-characters are treated as plain text and not executed.

We will modify the code in the `renderMermaid` function to use `textContent` instead of `innerHTML` for setting the content of the parent element.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
