### PR TITLE
Potential fix for code scanning alert no. 3: DOM text reinterpreted as HTML

### DIFF
--- a/docfx_project/templates/modern/src/markdown.ts
+++ b/docfx_project/templates/modern/src/markdown.ts
@@ -370,7 +370,7 @@ function renderTabs() {
     event.preventDefault()
     info.anchor.href = 'javascript:'
     setTimeout(function() {
-      info.anchor.href = '#' + info.anchor.getAttribute('aria-controls')
+      info.anchor.href = '#' + encodeURIComponent(info.anchor.getAttribute('aria-controls'))
     })
     const tabIds = info.tabIds; const group = info.group
     const originalTop = info.anchor.getBoundingClientRect().top


### PR DESCRIPTION
Potential fix for [https://github.com/MjrTom/puppeteer-sharp/security/code-scanning/3](https://github.com/MjrTom/puppeteer-sharp/security/code-scanning/3)

To fix the problem, we need to ensure that the value retrieved from the `aria-controls` attribute is properly sanitized or encoded before being used. In this case, since the value is being used as part of a URL fragment, we can use `encodeURIComponent` to safely encode the value.

- Replace the concatenation of `'#' + info.anchor.getAttribute('aria-controls')` with `'#' + encodeURIComponent(info.anchor.getAttribute('aria-controls'))`.
- This change ensures that any special characters in the `aria-controls` value are properly encoded, preventing potential XSS attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
