### PR TITLE
Potential fix for code scanning alert no. 4: DOM text reinterpreted as HTML

### DIFF
--- a/docfx_project/templates/default/styles/docfx.js
+++ b/docfx_project/templates/default/styles/docfx.js
@@ -9,6 +9,15 @@ $(function () {
   var hide = 'hide';
   var util = new utility();
 
+  function escapeHtml(unsafe) {
+    return unsafe
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#039;");
+  }
+
   workAroundFixedHeaderForAnchors();
   highlight();
   enableSearch();
@@ -283,7 +292,7 @@ $(function () {
               curHits.map(function (hit) {
                 var currentUrl = window.location.href;
                 var itemRawHref = relativeUrlToAbsoluteUrl(currentUrl, relHref + hit.href);
-                var itemHref = relHref + hit.href + "?q=" + query;
+                var itemHref = relHref + hit.href + "?q=" + escapeHtml(query);
                 var itemTitle = hit.title;
                 var itemBrief = extractContentBrief(hit.keywords);
 


### PR DESCRIPTION
Potential fix for [https://github.com/MjrTom/puppeteer-sharp/security/code-scanning/4](https://github.com/MjrTom/puppeteer-sharp/security/code-scanning/4)

To fix the problem, we need to ensure that the `query` variable is properly sanitized or escaped before being used in the `href` attribute. The best way to fix this issue is to use a function that escapes special characters in the `query` string to prevent it from being interpreted as HTML.

We will:
1. Create a function to escape special characters in a string.
2. Use this function to escape the `query` variable before using it in the `href` attribute.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
