### PR TITLE
Potential fix for code scanning alert no. 5: DOM text reinterpreted as HTML

### DIFF
--- a/docfx_project/templates/default/styles/docfx.js
+++ b/docfx_project/templates/default/styles/docfx.js
@@ -912,7 +912,7 @@ $(function () {
       }
       event.preventDefault();
       info.anchor.href = 'javascript:';
-      setTimeout(function () { return info.anchor.href = '#' + info.anchor.getAttribute('aria-controls'); });
+      setTimeout(function () { return info.anchor.href = '#' + encodeURIComponent(info.anchor.getAttribute('aria-controls')); });
       var tabIds = info.tabIds, group = info.group;
       var originalTop = info.anchor.getBoundingClientRect().top;
       if (group.independent) {


### PR DESCRIPTION
Potential fix for [https://github.com/MjrTom/puppeteer-sharp/security/code-scanning/5](https://github.com/MjrTom/puppeteer-sharp/security/code-scanning/5)

To fix the problem, we need to ensure that the value retrieved from `getAttribute('aria-controls')` is properly sanitized or encoded before being used. In this case, we can use a function to encode the value to ensure that any special characters are safely handled.

- We will create a function to encode the value retrieved from the DOM.
- We will replace the direct concatenation with a call to this encoding function.
- The changes will be made in the `docfx_project/templates/default/styles/docfx.js` file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
