### PR TITLE
Potential fix for code scanning alert no. 12: Uncontrolled command line

### DIFF
--- a/lib/PuppeteerSharp/BrowserFetcher.cs
+++ b/lib/PuppeteerSharp/BrowserFetcher.cs
@@ -222,10 +222,16 @@ namespace PuppeteerSharp
 
         private static void ExecuteSetup(string exePath, string folderPath)
         {
+            // Ensure the folderPath is a valid directory path
+            if (string.IsNullOrWhiteSpace(folderPath) || folderPath.IndexOfAny(Path.GetInvalidPathChars()) >= 0)
+            {
+                throw new ArgumentException("Invalid folder path provided.", nameof(folderPath));
+            }
+
             new DirectoryInfo(folderPath).Create();
             using var process = new Process();
             process.StartInfo.FileName = exePath;
-            process.StartInfo.Arguments = $"/ExtractDir={folderPath}";
+            process.StartInfo.ArgumentList.Add($"/ExtractDir={folderPath}");
             process.StartInfo.EnvironmentVariables.Add("__compat_layer", "RuAsInvoker");
             process.StartInfo.RedirectStandardOutput = true;
             process.StartInfo.UseShellExecute = false;


### PR DESCRIPTION
Potential fix for [https://github.com/MjrTom/puppeteer-sharp/security/code-scanning/12](https://github.com/MjrTom/puppeteer-sharp/security/code-scanning/12)

To fix the issue, we need to ensure that the `folderPath` value is sanitized and validated before being used in the command-line argument. This can be achieved by:
1. Verifying that `folderPath` is a valid directory path and does not contain any unexpected or malicious characters.
2. Using a safer method to pass arguments to the `Process.Start` method, such as avoiding string interpolation and instead using the `ProcessStartInfo.ArgumentList` property, which treats each argument as a separate entity.

The changes will be made in the `ExecuteSetup` method in `lib/PuppeteerSharp/BrowserFetcher.cs`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
